### PR TITLE
Refactor/rename exceptions

### DIFF
--- a/src/main/kotlin/logic/usecase/EggFreeSweetsUseCase.kt
+++ b/src/main/kotlin/logic/usecase/EggFreeSweetsUseCase.kt
@@ -2,8 +2,8 @@ package logic.usecase
 
 import model.Meal
 import logic.MealsProvider
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class EggFreeSweetsUseCase(
     private val mealsProvider: MealsProvider
@@ -12,13 +12,13 @@ class EggFreeSweetsUseCase(
     private val seenMeals = mutableSetOf<String>()
 
     fun execute(): Meal {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
         return mealsProvider.getMeals()
             .filter(::isEggFreeSweet)
             .takeIf { it.isNotEmpty() }
             ?.random()
             .also { seenMeals.add(it?.id.toString()) }
-            ?: throw NoElementMatch("There is no more egg free sweets")
+            ?: throw NoMealFoundException("There is no more egg free sweets")
     }
 
 

--- a/src/main/kotlin/logic/usecase/FilterQuickHealthyMealsUseCase.kt
+++ b/src/main/kotlin/logic/usecase/FilterQuickHealthyMealsUseCase.kt
@@ -2,20 +2,20 @@ package logic.usecase
 
 import logic.MealsProvider
 import model.Meal
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class FilterQuickHealthyMealsUseCase(private val mealsProvider: MealsProvider) {
 
     fun execute(count: Int): List<Meal> {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
 
         return mealsProvider.getMeals()
             .filter(::isQuickAndHasNutrition)
             .sortedBy(::healthScore)
             .take(count)
             .takeIf { it.isNotEmpty() }
-            ?: throw NoElementMatch("There is no more healthy meals")
+            ?: throw NoMealFoundException("There is no more healthy meals")
     }
 
     private fun isQuickAndHasNutrition(meal: Meal): Boolean {

--- a/src/main/kotlin/logic/usecase/GuessMealGameUseCase.kt
+++ b/src/main/kotlin/logic/usecase/GuessMealGameUseCase.kt
@@ -2,18 +2,18 @@ package logic.usecase
 
 import logic.MealsProvider
 import model.Meal
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class GuessMealGameUseCase(
     private val mealsProvider: MealsProvider
 ) {
     fun guessMealPreparationTime(): Meal {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
 
         return mealsProvider.getMeals()
             .takeIf { it.isNotEmpty() }
             ?.random()
-            ?: throw NoElementMatch("No meals found in the database")
+            ?: throw NoMealFoundException("No meals found in the database")
     }
 }

--- a/src/main/kotlin/logic/usecase/IraqiMealsIdentifierUseCase.kt
+++ b/src/main/kotlin/logic/usecase/IraqiMealsIdentifierUseCase.kt
@@ -2,20 +2,20 @@ package logic.usecase
 
 import logic.MealsProvider
 import model.Meal
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class IraqiMealsIdentifierUseCase(
     private val mealsProvider: MealsProvider
 ) {
 
     fun execute(): List<Meal> {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
 
         return mealsProvider.getMeals()
             .filter(::isIraqiMeal)
             .takeIf { it.isNotEmpty() }
-            ?: throw NoElementMatch("There is no Iraqi Meals")
+            ?: throw NoMealFoundException("There is no Iraqi Meals")
 
     }
 

--- a/src/main/kotlin/logic/usecase/MealsForLargeGroupUseCase.kt
+++ b/src/main/kotlin/logic/usecase/MealsForLargeGroupUseCase.kt
@@ -2,19 +2,19 @@ package logic.usecase
 
 import logic.MealsProvider
 import model.Meal
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class MealsForLargeGroupUseCase(private val mealsProvider: MealsProvider) {
 
     private val countryName = "Italy"
     private val query = "Large group"
     fun execute(): List<Meal> {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
         return mealsProvider.getMeals()
             .filter { grtMealsContainInput(it, countryName) && grtMealsContainInput(it, query) }
             .takeIf { it.isNotEmpty() }
-            ?: throw NoElementMatch("There is no item found")
+            ?: throw NoMealFoundException("There is no item found")
     }
 
     private fun grtMealsContainInput(meal: Meal, input: String): Boolean {

--- a/src/main/kotlin/logic/usecase/SeaFoodMealUseCase.kt
+++ b/src/main/kotlin/logic/usecase/SeaFoodMealUseCase.kt
@@ -2,15 +2,15 @@ package logic.usecase
 
 import model.Meal
 import logic.MealsProvider
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class SeaFoodMealUseCase(
     private val mealsProvider: MealsProvider
 ) {
 
     fun execute(): List<Pair<Int, Meal>> {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
         return mealsProvider.getMeals()
             .filter { meal ->
                 meal.tags!!.contains("seafood")
@@ -19,6 +19,6 @@ class SeaFoodMealUseCase(
             }.mapIndexed { index, meal ->
                 Pair(index + 1, meal)
             }.takeIf { it.isNotEmpty() }
-            ?: throw NoElementMatch("There is no Sea Food Meals")
+            ?: throw NoMealFoundException("There is no Sea Food Meals")
     }
 }

--- a/src/main/kotlin/logic/usecase/SearchFoodByDateUseCase.kt
+++ b/src/main/kotlin/logic/usecase/SearchFoodByDateUseCase.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.LocalDate
 import logic.MealsProvider
 import model.Meal
 import org.example.utils.InvalidDateFormatException
-import org.example.utils.NoMealsFoundException
+import org.example.utils.NoMealFoundException
 import java.time.format.DateTimeParseException
 
 class SearchFoodByDateUseCase(private val mealsProvider: MealsProvider) {
@@ -20,7 +20,7 @@ class SearchFoodByDateUseCase(private val mealsProvider: MealsProvider) {
         val meals = mealsProvider.getMeals().filter { it.date == searchDate }
 
         if (meals.isEmpty()) {
-            throw NoMealsFoundException("No meals found for date: $dateInput")
+            throw NoMealFoundException("No meals found for date: $dateInput")
         }
 
         return meals

--- a/src/main/kotlin/logic/usecase/SearchMealUseCase.kt
+++ b/src/main/kotlin/logic/usecase/SearchMealUseCase.kt
@@ -3,21 +3,21 @@ package logic.usecase
 import TextSearchUtil
 import logic.MealsProvider
 import model.Meal
-import org.example.utils.EmptyMealName
-import org.example.utils.NoElementMatch
-import org.example.utils.EmptyMeals
+import org.example.utils.EmptyMealNameException
+import org.example.utils.NoMealFoundException
+import org.example.utils.EmptyMealsException
 
 class SearchMealUseCase(
     private val mealsProvider: MealsProvider
 ) {
 
     fun execute(name: String): List<Meal> {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
-        if (name.isEmpty()) throw EmptyMealName("Name should not be empty")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
+        if (name.isEmpty()) throw EmptyMealNameException("Name should not be empty")
         val meals: List<Meal> = mealsProvider.getMeals().filter {
             findMeal(it.name!!.lowercase(), name.lowercase())
         }
-        if (meals.isEmpty()) throw NoElementMatch("No meals found matching '$name'.")
+        if (meals.isEmpty()) throw NoMealFoundException("No meals found matching '$name'.")
         return meals
     }
 

--- a/src/main/kotlin/logic/usecase/SuggestHighCalorieMealUseCase.kt
+++ b/src/main/kotlin/logic/usecase/SuggestHighCalorieMealUseCase.kt
@@ -2,20 +2,20 @@ package logic.usecase
 
 import model.Meal
 import logic.MealsProvider
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class SuggestHighCalorieMealUseCase(private val mealsProvider: MealsProvider) {
     private val suggestedMeals = mutableSetOf<Meal>()
 
     fun execute(): Meal {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
         return mealsProvider.getMeals()
             .filter(::isHighCalorieMeal)
             .takeIf { it.isNotEmpty() }
             ?.random()
             ?.also { suggestedMeals.add(it) }
-            ?: throw NoElementMatch("There is no High Calories meals")
+            ?: throw NoMealFoundException("There is no High Calories meals")
     }
 
     private fun isHighCalorieMeal(meal: Meal): Boolean =

--- a/src/main/kotlin/logic/usecase/SuggestKetoMealUseCase.kt
+++ b/src/main/kotlin/logic/usecase/SuggestKetoMealUseCase.kt
@@ -2,21 +2,21 @@ package logic.usecase
 
 import model.Meal
 import logic.MealsProvider
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class SuggestKetoMealUseCase(private val mealsProvider: MealsProvider) {
 
     private val alreadySuggestKetoMeals = mutableSetOf<Meal>()
 
     fun execute(): Meal {
-        if (mealsProvider.getMeals().isEmpty()) throw EmptyMeals("No meals found")
+        if (mealsProvider.getMeals().isEmpty()) throw EmptyMealsException("No meals found")
         return mealsProvider.getMeals()
             .filter(::isKetoMealAndNotSuggested)
             .takeIf { it.isNotEmpty() }
             ?.random()
             ?.also { alreadySuggestKetoMeals.add(it) }
-            ?: throw NoElementMatch("There is no more unique keto Meals")
+            ?: throw NoMealFoundException("There is no more unique keto Meals")
     }
 
     private fun isKetoMealAndNotSuggested(meal: Meal): Boolean {

--- a/src/main/kotlin/presentation/GuessGameUI.kt
+++ b/src/main/kotlin/presentation/GuessGameUI.kt
@@ -1,8 +1,8 @@
 package org.example.presentation
 
 import logic.usecase.GuessMealGameUseCase
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class GuessGameUI(private val useCase: GuessMealGameUseCase) : Feature {
     override val id: Int = FEATURE_ID
@@ -32,9 +32,9 @@ class GuessGameUI(private val useCase: GuessMealGameUseCase) : Feature {
             println("The correct time was $preparationTime minutes.")
 
 
-        }catch (e: EmptyMeals) {
+        }catch (e: EmptyMealsException) {
             println("There is no meals in database")
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println(
                 """There is no meals to be used in this game
                 |please try again later

--- a/src/main/kotlin/presentation/HighCalorieMealsUI.kt
+++ b/src/main/kotlin/presentation/HighCalorieMealsUI.kt
@@ -1,9 +1,9 @@
 package org.example.presentation
 
 import logic.usecase.SuggestHighCalorieMealUseCase
-import org.example.utils.EmptyMeals
+import org.example.utils.EmptyMealsException
 import org.example.utils.MealPresenter
-import org.example.utils.NoElementMatch
+import org.example.utils.NoMealFoundException
 
 class HighCalorieMealsUI(
     private val useCase: SuggestHighCalorieMealUseCase
@@ -34,9 +34,9 @@ class HighCalorieMealsUI(
                     println("Invalid input. Please enter 'y' or 'n'.")
                 }
             }
-        } catch (_: EmptyMeals) {
+        } catch (_: EmptyMealsException) {
             println("No meals in the database.")
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println(
                 """There is no high calories meal at the moment
                 |please try again later.

--- a/src/main/kotlin/presentation/IraqiMealsUI.kt
+++ b/src/main/kotlin/presentation/IraqiMealsUI.kt
@@ -2,7 +2,7 @@ package org.example.presentation
 
 import logic.usecase.IraqiMealsIdentifierUseCase
 import model.Meal
-import org.example.utils.NoElementMatch
+import org.example.utils.NoMealFoundException
 
 class IraqiMealsUI(private val useCase: IraqiMealsIdentifierUseCase) : Feature {
     override val id: Int = FEATURE_ID
@@ -12,7 +12,7 @@ class IraqiMealsUI(private val useCase: IraqiMealsIdentifierUseCase) : Feature {
         try {
             val meals = useCase.execute()
             printMealsTable(meals)
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println("There is no Iraqi meals found")
         } catch (e: Exception) {
             println(

--- a/src/main/kotlin/presentation/ItalianForLargeGroupsUI.kt
+++ b/src/main/kotlin/presentation/ItalianForLargeGroupsUI.kt
@@ -1,8 +1,8 @@
 package org.example.presentation
 
 import logic.usecase.MealsForLargeGroupUseCase
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class ItalianForLargeGroupsUI(
     private val useCase: MealsForLargeGroupUseCase
@@ -17,9 +17,9 @@ class ItalianForLargeGroupsUI(
             meals.forEachIndexed { index, meal ->
                 println("${index + 1} - ${meal.name}")
             }
-        } catch (_: EmptyMeals) {
+        } catch (_: EmptyMealsException) {
             println("No meals in the database.")
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println(
                 """There is no meals for large group at the moment
                 |please try again later

--- a/src/main/kotlin/presentation/KetoFriendlyMealUI.kt
+++ b/src/main/kotlin/presentation/KetoFriendlyMealUI.kt
@@ -1,9 +1,9 @@
 package org.example.presentation
 
 import logic.usecase.SuggestKetoMealUseCase
-import org.example.utils.EmptyMeals
+import org.example.utils.EmptyMealsException
 import org.example.utils.MealPresenter
-import org.example.utils.NoElementMatch
+import org.example.utils.NoMealFoundException
 
 class KetoFriendlyMealUI(private val useCase: SuggestKetoMealUseCase) : Feature {
     override val id: Int = FEATURE_ID
@@ -25,9 +25,9 @@ class KetoFriendlyMealUI(private val useCase: SuggestKetoMealUseCase) : Feature 
                     suggestedMeal = useCase.execute()
                 } else println("Invalid input. Please enter 'y' or 'n'.")
             }
-        } catch (_: EmptyMeals) {
+        } catch (_: EmptyMealsException) {
             println("No meals in the database.")
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println("There is no more unique keto Meals")
         } catch (e: Exception) {
             println("There is a problem happened when retrieving the data")

--- a/src/main/kotlin/presentation/MealSearchUI.kt
+++ b/src/main/kotlin/presentation/MealSearchUI.kt
@@ -1,9 +1,9 @@
 package org.example.presentation
 
 import logic.usecase.SearchMealUseCase
-import org.example.utils.EmptyMealName
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealNameException
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class MealSearchUI(private val useCase: SearchMealUseCase) : Feature {
     override val id: Int = FEATURE_ID
@@ -16,11 +16,11 @@ class MealSearchUI(private val useCase: SearchMealUseCase) : Feature {
             val meals = useCase.execute(keyword)
             println("Matching Meals:\n${meals.joinToString("\n") { "- ${it.name} " }}")
 
-        } catch (_: EmptyMeals) {
+        } catch (_: EmptyMealsException) {
             println("No meals in the database.")
-        } catch (_: EmptyMealName) {
+        } catch (_: EmptyMealNameException) {
             println("Meal name should not be empty")
-        } catch (_: NoElementMatch) {
+        } catch (_: NoMealFoundException) {
             println("No meals found matching '$keyword'.")
         } catch (_: Exception) {
             println("There is a problem happened when retrieving the data.")

--- a/src/main/kotlin/presentation/QuickHealthyMealsUI.kt
+++ b/src/main/kotlin/presentation/QuickHealthyMealsUI.kt
@@ -1,8 +1,8 @@
 package org.example.presentation
 
 import logic.usecase.FilterQuickHealthyMealsUseCase
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class QuickHealthyMealsUI(private val useCase: FilterQuickHealthyMealsUseCase) : Feature {
     override val id: Int = FEATURE_ID
@@ -24,9 +24,9 @@ class QuickHealthyMealsUI(private val useCase: FilterQuickHealthyMealsUseCase) :
                     println("Quick & Healthy Meals:")
                     meals.forEach { println("- ${it.name}") }
                 }
-            } catch (e: EmptyMeals) {
+            } catch (e: EmptyMealsException) {
                 println("There is no meals in database")
-            } catch (e: NoElementMatch) {
+            } catch (e: NoMealFoundException) {
                 println("There are no quick healthy meals available ")
             } catch (e: Exception) {
                 println("There is a problem happened when retrieving the data.")

--- a/src/main/kotlin/presentation/SeafoodMealsUI.kt
+++ b/src/main/kotlin/presentation/SeafoodMealsUI.kt
@@ -1,8 +1,8 @@
 package org.example.presentation
 
 import logic.usecase.SeaFoodMealUseCase
-import org.example.utils.EmptyMeals
-import org.example.utils.NoElementMatch
+import org.example.utils.EmptyMealsException
+import org.example.utils.NoMealFoundException
 
 class SeafoodMealsUI(
     private val useCase: SeaFoodMealUseCase
@@ -17,9 +17,9 @@ class SeafoodMealsUI(
             rankedMeals.forEach { (rank, meal) ->
                 println("$rank      ${meal.name}     ${meal.nutrition!!.protein}")
             }
-        } catch (e: EmptyMeals) {
+        } catch (e: EmptyMealsException) {
             println("There is no meals in database")
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println("There is no seafood meals found")
         } catch (e: Exception) {
             println("There is a problem happened when retrieving the data.")

--- a/src/main/kotlin/presentation/SearchFoodByDateUI.kt
+++ b/src/main/kotlin/presentation/SearchFoodByDateUI.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.LocalDate
 import logic.usecase.SearchFoodByDateUseCase
 import org.example.utils.InvalidDateFormatException
 import org.example.utils.MealPresenter
-import org.example.utils.NoMealsFoundException
+import org.example.utils.NoMealFoundException
 
 class SearchFoodByDateUI(
     private val useCase: SearchFoodByDateUseCase
@@ -43,7 +43,7 @@ class SearchFoodByDateUI(
 
         } catch (e: InvalidDateFormatException) {
             println("Error: ${e.message}")
-        } catch (e: NoMealsFoundException) {
+        } catch (e: NoMealFoundException) {
             println("Notice: ${e.message}")
         }
     }

--- a/src/main/kotlin/presentation/SweetsWithNoEggsUI.kt
+++ b/src/main/kotlin/presentation/SweetsWithNoEggsUI.kt
@@ -1,9 +1,9 @@
 package org.example.presentation
 
 import logic.usecase.EggFreeSweetsUseCase
-import org.example.utils.EmptyMeals
+import org.example.utils.EmptyMealsException
 import org.example.utils.MealPresenter
-import org.example.utils.NoElementMatch
+import org.example.utils.NoMealFoundException
 
 class SweetsWithNoEggsUI(private val useCase: EggFreeSweetsUseCase) : Feature {
     override val id: Int = FEATURE_ID
@@ -21,9 +21,9 @@ class SweetsWithNoEggsUI(private val useCase: EggFreeSweetsUseCase) : Feature {
                     break
                 }
             }
-        } catch (e: EmptyMeals) {
+        } catch (e: EmptyMealsException) {
             println("There is no meals in database")
-        } catch (e: NoElementMatch) {
+        } catch (e: NoMealFoundException) {
             println("There is no egg free sweets found")
         } catch (e: Exception) {
             println(

--- a/src/main/kotlin/utils/Exceptions.kt
+++ b/src/main/kotlin/utils/Exceptions.kt
@@ -1,7 +1,6 @@
 package org.example.utils
 
-class EmptyMealName(message : String)  : Exception(message)
-class EmptyMeals(message : String)  : Exception(message)
-class NoElementMatch(message : String)  : NoSuchElementException(message)
+class EmptyMealNameException(message : String)  : Exception(message)
+class EmptyMealsException(message : String)  : Exception(message)
+class NoMealFoundException(message : String)  : NoSuchElementException(message)
 class InvalidDateFormatException(message: String) : Exception(message)
-class NoMealsFoundException(message: String) : Exception(message)


### PR DESCRIPTION
## :information_source: PR Info
### :page_facing_up: Description
Rename customized exceptions in utils/exceptions

add exception suffix to following customized exceptions  
1 - from EmptyMealName to EmptyMealNameException
2 - from EmptyMeals to EmptyMealsException
3 - from NoElementMatch to NoMealFoundException
4 - delete  NoElementMatch , NoMealFoundException

##### Why we need this change?
 - to make it more clear for an exceptions